### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This library is the Client library for a Minecraft Game Skills and MCP Integrati
 
 Fairies MCP Client (<https://fairies.ai/>) also supports direct connection with a single click.
 
+<a href="https://glama.ai/mcp/servers/@leo4life2/minecraft-mcp-http">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@leo4life2/minecraft-mcp-http/badge" alt="Minecraft Server MCP server" />
+</a>
+
 ## Features
 
 - **Full Minecraft Control**: Connect AI agents to Minecraft servers and control bots


### PR DESCRIPTION
This PR adds a badge for the [Minecraft MCP Server](https://glama.ai/mcp/servers/@leo4life2/minecraft-mcp-http) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@leo4life2/minecraft-mcp-http">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@leo4life2/minecraft-mcp-http/badge" alt="Minecraft Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.